### PR TITLE
Fix: Add missing props in component calendar navigation icons

### DIFF
--- a/apps/www/registry/default/ui/calendar.tsx
+++ b/apps/www/registry/default/ui/calendar.tsx
@@ -55,7 +55,7 @@ function Calendar({
       }}
       components={{
         IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" { ...props } />,
-        IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" { ...props } />,
+        IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4"  { ...props } />,
       }}
       {...props}
     />


### PR DESCRIPTION
Fixed an issue where additional props destructured from IconLeft and IconRight were not being forwarded to the Chevron navigation icons in the Calendar component, making them to be ignored