### PR TITLE
Fix: Add missing props in component calendar navigation icons

### DIFF
--- a/apps/www/registry/new-york/ui/calendar.tsx
+++ b/apps/www/registry/new-york/ui/calendar.tsx
@@ -60,8 +60,8 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" />,
-        IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" />,
+        IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" { ...props } />,
+        IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" { ...props } />,
       }}
       {...props}
     />


### PR DESCRIPTION
Fixed an issue where additional props destructured from IconLeft and IconRight were not being forwarded to the Chevron navigation icons in the Calendar component, making them to be ignored.